### PR TITLE
chore: Match react types version

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -45,7 +45,7 @@
 		"@types/jest": "^27.4.1",
 		"@types/node": "^17.0.15",
 		"@types/react": "^17.0.2",
-		"@types/react-dom": "^17.0.11",
+		"@types/react-dom": "^17.0.2",
 		"@types/styled-components": "^5.1.22",
 		"babel-jest": "^28.0.3",
 		"babel-loader": "^8.2.5",


### PR DESCRIPTION
This PR matches the types versions for both react & react-dom to the ones installed in the FE package