### PR TITLE
fix: FE image URL format

### DIFF
--- a/packages/frontend/components/Portfolio/PortfolioList.tsx
+++ b/packages/frontend/components/Portfolio/PortfolioList.tsx
@@ -1,7 +1,6 @@
 import { Project as ProjectProps } from "lib/hooks/useProject"
 import { useState } from "react"
 import useOnclickOutside from "react-cool-onclickoutside"
-import { imageUrlFormat } from "util/imageUrlFormat"
 import {
 	PortfolioContainer,
 	PortfolioModalCloseButton,
@@ -64,9 +63,7 @@ const PortfolioList = ({ portfolio }: { portfolio: ProjectProps[] }) => {
 							projectId={projectId}
 							name={name}
 							tags={tags}
-							imgSrc={imageUrlFormat(
-								galleryAssets[0].media.formats.small.url,
-							)}
+							imgSrc={galleryAssets[0].media.formats.small.url}
 							handleClick={changeActiveProject}
 						/>
 					),

--- a/packages/frontend/components/Portfolio/PortfolioModal.tsx
+++ b/packages/frontend/components/Portfolio/PortfolioModal.tsx
@@ -1,7 +1,6 @@
 import { Project } from "lib/hooks/useProject"
 import { Return } from "react-cool-onclickoutside"
 import { getBiggestFormatImage } from "util/getSelectFormatImage"
-import { imageUrlFormat } from "util/imageUrlFormat"
 import {
 	PorfolioModalTagContainer,
 	PortfolioModal as PortfolioModalBase,
@@ -34,10 +33,10 @@ const PortfolioModal = ({
 		<PortfolioModalBase active={active} ref={onClickOutside}>
 			<div>
 				<PortfolioModalImage
-					src={imageUrlFormat(
+					src={
 						getBiggestFormatImage(galleryAssets[0].media.formats)
-							.url,
-					)}
+							.url
+					}
 					alt={name}
 				/>
 			</div>

--- a/packages/frontend/components/Project/ProjectGallery.tsx
+++ b/packages/frontend/components/Project/ProjectGallery.tsx
@@ -9,7 +9,6 @@ import {
 	getBiggestFormatImage,
 	getSmallestFormatImage,
 } from "util/getSelectFormatImage"
-import { imageUrlFormat } from "util/imageUrlFormat"
 import { fetchProjectGalleryItemSubindex } from "util/projectGallerySubindexFetcher"
 import { ProjectGalleryItem } from "./ProjectGalleryItem"
 
@@ -56,12 +55,8 @@ export const ProjectGalleryWrapper = ({
 						label={label}
 						size={`${getBiggestFormatImage(media.formats).size}`}
 						assetCaption={`<h4>${label}</h4>`}
-						assetUrl={imageUrlFormat(
-							getBiggestFormatImage(media.formats).url,
-						)}
-						thumbnailUrl={imageUrlFormat(
-							getSmallestFormatImage(media.formats).url,
-						)}
+						assetUrl={getBiggestFormatImage(media.formats).url}
+						thumbnailUrl={getSmallestFormatImage(media.formats).url}
 					/>
 				)
 			}),

--- a/packages/frontend/components/Project/index.tsx
+++ b/packages/frontend/components/Project/index.tsx
@@ -1,5 +1,4 @@
 import { Project as ProjectProps } from "lib/hooks/useProject"
-import { imageUrlFormat } from "util/imageUrlFormat"
 import {
 	ProjectContentHolder,
 	ProjectHeaderTitle,
@@ -17,10 +16,7 @@ export const Project = ({ project }: { project: ProjectProps }) => {
 	return (
 		<>
 			<ProjectJumbotron accent={accentColor}>
-				<ProjectJumbotronLogo
-					src={imageUrlFormat(logo.url)}
-					alt={name}
-				/>
+				<ProjectJumbotronLogo src={logo.url} alt={name} />
 			</ProjectJumbotron>
 			<ProjectContentHolder>
 				<ProjectSection>

--- a/packages/frontend/util/imageUrlFormat.ts
+++ b/packages/frontend/util/imageUrlFormat.ts
@@ -1,2 +1,0 @@
-export const imageUrlFormat = (baseImageUrl: string) =>
-	`${process.env.NEXT_PUBLIC_BACKEND_URL}${baseImageUrl}`


### PR DESCRIPTION
This PR gets rid of a previously-needed image URL formatter for the FE. Not needed after AWS S3 changes for the BE