### PR TITLE
fix: Add Node version to BE package.json

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,6 +12,9 @@
 		"format": "prettier --write \"{src,config}/**/*.ts\"",
 		"lint": "eslint \"{src,config}/**/*.ts\""
 	},
+	"engines": {
+		"node": "18.17.1"
+	},
 	"dependencies": {
 		"@strapi/plugin-graphql": "4.15.1",
 		"@strapi/plugin-i18n": "4.15.1",


### PR DESCRIPTION
This PR specifies the node version for the BE package, same as that of the main repo package (`v18.17.1`) due to a Heroku restraint that defaults to the latest LTS version (currently `v20.9.0`)